### PR TITLE
Fix for executable

### DIFF
--- a/fetchurls.sh
+++ b/fetchurls.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 VERSION="v3.2.4"
 


### PR DESCRIPTION
The script is not usable until you change this to `bash`.